### PR TITLE
infrastructure_training: レビューに基づくEmacsインストール、PHPバージョン更新、およびログ設定の改善

### DIFF
--- a/new_graduate_training/repo/.progate/start_php_web_app.sh
+++ b/new_graduate_training/repo/.progate/start_php_web_app.sh
@@ -14,7 +14,7 @@ fi
 . "$QUESTIONS_SH_FILEPATH"
 
 # 指定されたURLにHTTPリクエストを送信し、レスポンスを取得
-URL="http://$AWS_EC2_HOST/index.php"
+URL="http://$AWS_EC2_HOST/test.php"
 RESPONSE=$(curl -o /dev/null -s -w "%{http_code}\n" "$URL")
 
 # ステータスコードが200であるかどうかを確認

--- a/new_graduate_training/tasks/infrastructure_training.jsonc
+++ b/new_graduate_training/tasks/infrastructure_training.jsonc
@@ -209,7 +209,7 @@
   "lifecycleStages": {
     "development": "active",
     "staging": "active",
-    "production": "draft"
+    "production": "active"
   },
   "arielOption": {
     "skip": true

--- a/new_graduate_training/tasks/infrastructure_training/explainer_ja.md
+++ b/new_graduate_training/tasks/infrastructure_training/explainer_ja.md
@@ -151,7 +151,7 @@ $ sudo systemctl disable apache2
 ディレクトリの内容を表示するコマンド。ファイルやディレクトリの一覧を表示する。
 
 ```terminal
-$ ls /etc/php/8.1/fpm/pool.d/
+$ ls /etc/php/8.3/fpm/pool.d/
 ```
 
 ### cat
@@ -159,7 +159,7 @@ $ ls /etc/php/8.1/fpm/pool.d/
 ファイルの内容を表示するコマンド。ファイルの内容を表示する際に使用する。
 
 ```terminal
-$ cat /etc/php/8.1/fpm/php-fpm.conf
+$ cat /etc/php/8.3/fpm/php-fpm.conf
 ```
 
 ### nginx

--- a/new_graduate_training/tasks/infrastructure_training/locales/translations.yml
+++ b/new_graduate_training/tasks/infrastructure_training/locales/translations.yml
@@ -42,7 +42,7 @@ infrastructure_training:
         ja: サーバーのプロセス・メモリ・ディスクが確認できている
     start_php_web_app:
       title:
-        ja: Webサーバーにindex.phpファイルが置かれている
+        ja: Webサーバーにtest.phpファイルが置かれている
     php_fpm:
       title:
         ja: Apache2が停止している

--- a/new_graduate_training/tasks/infrastructure_training/task_items/check_server_status_ja.md
+++ b/new_graduate_training/tasks/infrastructure_training/task_items/check_server_status_ja.md
@@ -212,15 +212,10 @@ $ which nano
 /usr/bin/nano
 $ which vi
 /usr/bin/vi
-$ which emacs
 
 ```
 
-`nano` と `vi` がインストールされていることがわかります。`emacs` はインストールされていないため、何も出力されないようです。好みに応じてこれらのエディタをインストールできます。
-
-```terminal
-$ sudo apt update && sudo apt install emacs
-```
+`nano` と `vi` がインストールされていることがわかります。好みに応じて利用してください。
 
 ### ~/.bashrc を開いてみよう
 
@@ -260,6 +255,7 @@ ANSWER_CHECK_SERVER_STATUS_MEM_USED_MIB=000.0
 # このサーバーのディスク容量はどのぐらい？そのうちどのぐらい使われてる？
 ANSWER_CHECK_SERVER_STATUS_DISK_TOTAL_GB="0.0G"
 ANSWER_CHECK_SERVER_STATUS_DISK_USED_GB="0.0G"
+```
 
 ```terminal
 $ progate submit

--- a/new_graduate_training/tasks/infrastructure_training/task_items/overload_the_server_ja.md
+++ b/new_graduate_training/tasks/infrastructure_training/task_items/overload_the_server_ja.md
@@ -7,7 +7,7 @@ Nginx はアクセスログを使用してリクエストの情報を記録し�
 まずは既存のアクセスログを確認してみましょう。Nginx のアクセスログは通常、`/var/log/nginx/access.log` に保存されています。`tail` コマンドを使用して、アクセスログの内容を表示します。
 
 ```terminal
-$ tail /var/log/nginx/access.log 
+$ tail -f /var/log/nginx/access.log 
 # 例
 192.168.1.1 - - [31/Mar/2024:00:10:40 +0000] "GET /test.php HTTP/1.1" 200 804 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.85 Safari/537.36 Edg/90.0.818.46"
 ```
@@ -101,7 +101,7 @@ Nginx では、`$request_time` 変数を使用してレスポンスタイムを�
     http {
 
         # その他の設定...
-        
+
         ##
         # Logging Settings
         ##

--- a/new_graduate_training/tasks/infrastructure_training/task_items/php_fpm_ja.md
+++ b/new_graduate_training/tasks/infrastructure_training/task_items/php_fpm_ja.md
@@ -69,80 +69,66 @@ $ sudo systemctl enable apache2
 $ sudo systemctl disable apache2
 ```
 
-### aptでphp8.1-fpmをインストールしてみよう
+### aptでphp8.3-fpmをインストールしてみよう
 
-PHP 8.1 の FastCGI プロセスマネージャ（php-fpm）をインストールします。
-
-```terminal
-$ sudo apt install php8.1-fpm
-```
-
-もし、php8.1-fpm が見つからないというエラーが出る場合は下記を実行したあとに再度インストールしてみてください。
+PHP 8.3 の FastCGI プロセスマネージャ（php-fpm）をインストールします。
 
 ```terminal
-$ sudo apt update && sudo apt install -y software-properties-common 
-$ sudo add-apt-repository ppa:ondrej/php
-$ sudo apt update
+$ sudo apt install php8.3-fpm
 ```
-
-インストール時に下記のような画面が表示される場合があるので、デフォルトの選択肢で OK します。
-
-- <img width="580" alt="image" src="https://github.com/Progate/path-community-projects/assets/26600620/5e8edd66-e2aa-4ae3-80b3-604831bde64b">
-- <img width="580" alt="image" src="https://github.com/Progate/path-community-projects/assets/26600620/c3bec52a-9c8c-472f-82b9-d85cda042d1d">
 
 ### php-fpmの状態を確認してみよう
 
-`sudo systemctl status php8.1-fpm` コマンドを使って、`php-fpm` の状態を確認します。
+`sudo systemctl status php8.3-fpm` コマンドを使って、`php-fpm` の状態を確認します。
 
 ```terminal
-$ sudo systemctl status php8.1-fpm
-● php8.1-fpm.service - The PHP 8.1 FastCGI Process Manager
-     Loaded: loaded (/lib/systemd/system/php8.1-fpm.service; enabled; vendor pre>
-     Active: active (running) since Fri 2024-03-29 07:13:52 UTC; 11s ago
-       Docs: man:php-fpm8.1(8)
-    Process: 22935 ExecStartPost=/usr/lib/php/php-fpm-socket-helper install /run>
-   Main PID: 22932 (php-fpm8.1)
-     Status: "Processes active: 0, idle: 2, Requests: 0, slow: 0, Traffic: 0req/>
-      Tasks: 3 (limit: 517)
-     Memory: 7.2M
-        CPU: 44ms
-     CGroup: /system.slice/php8.1-fpm.service
-             ├─22932 "php-fpm: master process (/etc/php/8.1/fpm/php-fpm.conf)" ">
-             ├─22933 "php-fpm: pool www" "" "" "" "" "" "" "" "" "" "" "" "" "" >
-             └─22934 "php-fpm: pool www" "" "" "" "" "" "" "" "" "" "" "" "" "" >
+$ sudo systemctl status php8.3-fpm
+● php8.3-fpm.service - The PHP 8.3 FastCGI Process Manager
+     Loaded: loaded (/usr/lib/systemd/system/php8.3-fpm.service; enabled; preset: enabled)
+     Active: active (running) since Tue 2024-06-04 04:20:29 UTC; 1min 39s ago
+       Docs: man:php-fpm8.3(8)
+    Process: 9850 ExecStartPost=/usr/lib/php/php-fpm-socket-helper install /run/php/php-fpm.sock /etc/php/8.3/fpm/pool.d/www.conf 83 (code=exited, status=0/SUCCESS)
+   Main PID: 9846 (php-fpm8.3)
+     Status: "Processes active: 0, idle: 2, Requests: 0, slow: 0, Traffic: 0req/sec"
+      Tasks: 3 (limit: 526)
+     Memory: 8.3M (peak: 8.8M)
+        CPU: 55ms
+     CGroup: /system.slice/php8.3-fpm.service
+             ├─9846 "php-fpm: master process (/etc/php/8.3/fpm/php-fpm.conf)"
+             ├─9848 "php-fpm: pool www"
+             └─9849 "php-fpm: pool www"
 
-Mar 29 07:13:52 ip-172-31-36-76 systemd[1]: php8.1-fpm.service: Deactivated succ>
-Mar 29 07:13:52 ip-172-31-36-76 systemd[1]: Stopped The PHP 8.1 FastCGI Process >
-Mar 29 07:13:52 ip-172-31-36-76 systemd[1]: Starting The PHP 8.1 FastCGI Process>
-Mar 29 07:13:52 ip-172-31-36-76 systemd[1]: Started The PHP 8.1 FastCGI Proces
+Jun 04 04:20:29 ip-172-31-32-171 systemd[1]: Starting php8.3-fpm.service - The PHP 8.3 FastCGI Process Manager...
+Jun 04 04:20:29 ip-172-31-32-171 systemd[1]: Started php8.3-fpm.service - The PHP 8.3 FastCGI Process Manager.
 ```
 
 ### php-fpmのプロセスはいくつ起動してる？
 
-出力によると、`php8.1-fpm` サービスにはメインのプロセス（マスタープロセス）が 1 つと、`pool www` として実行されている子プロセスが 2 つあります。したがって、合計で 3 つのプロセスが起動しています。これは、`CGroup` セクションに表示されている以下の行から確認できます。
+出力によると、`php8.3-fpm` サービスにはメインのプロセス（マスタープロセス）が 1 つと、`pool www` として実行されている子プロセスが 2 つあります。したがって、合計で 3 つのプロセスが起動しています。これは、`CGroup` セクションに表示されている以下の行から確認できます。
 
 ```sh
-             ├─22932 "php-fpm: master process (/etc/php/8.1/fpm/php-fpm.conf)" ">
-             ├─22933 "php-fpm: pool www" "" "" "" "" "" "" "" "" "" "" "" "" "" >
-             └─22934 "php-fpm: pool www" "" "" "" "" "" "" "" "" "" "" "" "" "" >
+CGroup: /system.slice/php8.3-fpm.service
+             ├─9846 "php-fpm: master process (/etc/php/8.3/fpm/php-fpm.conf)"
+             ├─9848 "php-fpm: pool www"
+             └─9849 "php-fpm: pool www"
 ```
 
 ### php-fpm の設定ファイルはどこにある？
 
-`php-fpm` の設定ファイルのパスは、マスタープロセスの記述に明示的に記載されています。これは `/etc/php/8.1/fpm/php-fpm.conf` です。これが `php-fpm` のメインの設定ファイルであり、`php-fpm` の動作やプール設定などをカスタマイズする際に編集します。
+`php-fpm` の設定ファイルのパスは、マスタープロセスの記述に明示的に記載されています。これは `/etc/php/8.3/fpm/php-fpm.conf` です。これが `php-fpm` のメインの設定ファイルであり、`php-fpm` の動作やプール設定などをカスタマイズする際に編集します。
 
 ```sh
-             ├─22932 "php-fpm: master process (/etc/php/8.1/fpm/php-fpm.conf)" ">
+             ├─9846 "php-fpm: master process (/etc/php/8.3/fpm/php-fpm.conf)"
 ```
 
-このパスから、PHP 8.1 用の `php-fpm` の設定ファイルが `/etc/php/8.1/fpm/` ディレクトリ内にあり、ファイル名は `php-fpm.conf` であることがわかります。この情報をもとに、必要に応じて `php-fpm` の設定を調整できます。
+このパスから、PHP 8.3 用の `php-fpm` の設定ファイルが `/etc/php/8.3/fpm/` ディレクトリ内にあり、ファイル名は `php-fpm.conf` であることがわかります。この情報をもとに、必要に応じて `php-fpm` の設定を調整できます。
 
 ### 設定ファイルを開いてみよう
 
 確認した設定ファイルを開いてみましょう。
 
 ```terminal
-$ cat /etc/php/8.1/fpm/php-fpm.conf
+$ cat /etc/php/8.3/fpm/php-fpm.conf
 ;;;;;;;;;;;;;;;;;;;;;
 ; FPM Configuration ;
 ;;;;;;;;;;;;;;;;;;;;;
@@ -161,14 +147,14 @@ $ cat /etc/php/8.1/fpm/php-fpm.conf
 ; Default Value: none
 ; Warning: if you change the value here, you need to modify systemd
 ; service PIDFile= setting to match the value here.
-pid = /run/php/php8.1-fpm.pid
+pid = /run/php/php8.3-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written
 ; into a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-error_log = /var/log/php8.1-fpm.log
+error_log = /var/log/php8.3-fpm.log
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities
@@ -287,7 +273,7 @@ error_log = /var/log/php8.1-fpm.log
 ; Relative path can also be used. They will be prefixed by:
 ;  - the global prefix if it's been set (-p argument)
 ;  - /usr otherwise
-include=/etc/php/8.1/fpm/pool.d/*.conf
+include=/etc/php/8.3/fpm/pool.d/*.conf
 
 ```
 
@@ -306,20 +292,20 @@ include=/etc/php/8.1/fpm/pool.d/*.conf
 この質問は、`php-fpm` がどのソケットファイルを使ってリッスンしているかを特定することに関連しています。具体的な場所は、`php-fpm` のプール設定ファイル (`*.conf`) 内で指定されます。以下は、設定ファイルの探索方法とソケットファイルの位置の確認方法です：
 
 ```sh
-include=/etc/php/8.1/fpm/pool.d/*.conf
+include=/etc/php/8.3/fpm/pool.d/*.conf
 ```
 
-このディレクティブは、`/etc/php/8.1/fpm/pool.d/` ディレクトリ内のすべての `.conf` ファイルをインクルードすることを示しています。ソケットファイルの設定は、これらのプール設定ファイルに記述されています。
+このディレクティブは、`/etc/php/8.3/fpm/pool.d/` ディレクトリ内のすべての `.conf` ファイルをインクルードすることを示しています。ソケットファイルの設定は、これらのプール設定ファイルに記述されています。
 
 プール設定ファイルを確認して、`php-fpm` がリッスンしているソケットファイルまたはポートを特定します。以下のコマンドを使って、プール設定ファイルを確認できます。
 
 ```terminal
-$ ls /etc/php/8.1/fpm/pool.d/
+$ ls /etc/php/8.3/fpm/pool.d/
 www.conf
-$ cat /etc/php/8.1/fpm/pool.d/www.conf | grep "^listen ="
-listen = /run/php/php8.1-fpm.sock
+$ cat /etc/php/8.3/fpm/pool.d/www.conf | grep "^listen ="
+listen = /run/php/php8.3-fpm.sock
 ```
 
-この設定は、`php-fpm` が UNIX ドメインソケット `/run/php/php8.1-fpm.sock` を使用してリッスンしていることを意味します。ウェブサーバー（Apache や Nginx など）は、PHP コンテンツを処理するためにこのソケットファイル経由で `php-fpm` にリクエストを送信するように設定する必要があります。
+この設定は、`php-fpm` が UNIX ドメインソケット `/run/php/php8.3-fpm.sock` を使用してリッスンしていることを意味します。ウェブサーバー（Apache や Nginx など）は、PHP コンテンツを処理するためにこのソケットファイル経由で `php-fpm` にリクエストを送信するように設定する必要があります。
 
-以上から、`php-fpm` がリッスンしているソケットファイルの場所は `/run/php/php8.1-fpm.sock` と特定できます。
+以上から、`php-fpm` がリッスンしているソケットファイルの場所は `/run/php/php8.3-fpm.sock` と特定できます。

--- a/new_graduate_training/tasks/infrastructure_training/task_items/start_php_web_app_ja.md
+++ b/new_graduate_training/tasks/infrastructure_training/task_items/start_php_web_app_ja.md
@@ -97,10 +97,10 @@ index.html
 
 次は PHP ファイルを配置して、PHP の実行結果をブラウザからアクセスしてみましょう。その際、`SERVER_SOFTWARE` の値を確認します。
 
-1. index.php を作成し、以下のコードを記述します。`vi` や `nano` などのエディタを使用して、index.php ファイルを作成します。
+1. test.php を作成し、以下のコードを記述します。`vi` や `nano` などのエディタを使用して、test.php ファイルを作成します。
 
     ```terminal
-    $ vi index.php
+    $ vi test.php
     ```
 
     ```php
@@ -112,29 +112,29 @@ index.html
     :wq
     ```
 
-2. index.php を `/var/www/html` ディレクトリに配置します。
+2. test.php を `/var/www/html` ディレクトリに配置します。
 
     ```terminal
-    $ sudo mv index.php /var/www/html
+    $ sudo mv test.php /var/www/html
     ```
 
 3. ブラウザでアクセスして、`SERVER_SOFTWARE` の値を確認します。
 
-    - `http://[IPアドレス もしくは Public DNS の値]/index.php`
+    - `http://[IPアドレス もしくは Public DNS の値]/test.php`
 
     例えば、以下のような結果が表示されます。
 
     ```php
     array(32) { ["HTTP_HOST"]=> string(14) "xxx.xxx.xxx.xxx" ["HTTP_CONNECTION"]=> string(10) "keep-alive" ["HTTP_CACHE_CONTROL"]=> string(9) "max-age=0" ["HTTP_UPGRADE_INSECURE_REQUESTS"]=> string(1) "1" ["HTTP_USER_AGENT"]=> string(117) "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36" ["HTTP_ACCEPT"]=> string(96) "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8" ["HTTP_SEC_GPC"]=> string(1) "1" ["HTTP_ACCEPT_LANGUAGE"]=> string(8) "en-US,en" ["HTTP_ACCEPT_ENCODING"]=> string(13) "gzip, deflate" ["PATH"]=> string(70) "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin" ["SERVER_SIGNATURE"]=> string(75) "
-    Apache/2.4.52 (Ubuntu) Server at xxx.xxx.xxx.xxx Port 80
-    " ["SERVER_SOFTWARE"]=> string(22) "Apache/2.4.52 (Ubuntu)" ["SERVER_NAME"]=> string(14) "xxx.xxx.xxx.xxx" ["SERVER_ADDR"]=> string(12) "172.31.36.76" ["SERVER_PORT"]=> string(2) "80" ["REMOTE_ADDR"]=> string(14) "133.106.241.38" ["DOCUMENT_ROOT"]=> string(13) "/var/www/html" ["REQUEST_SCHEME"]=> string(4) "http" ["CONTEXT_PREFIX"]=> string(0) "" ["CONTEXT_DOCUMENT_ROOT"]=> string(13) "/var/www/html" ["SERVER_ADMIN"]=> string(19) "webmaster@localhost" ["SCRIPT_FILENAME"]=> string(23) "/var/www/html/index.php" ["REMOTE_PORT"]=> string(5) "50368" ["GATEWAY_INTERFACE"]=> string(7) "CGI/1.1" ["SERVER_PROTOCOL"]=> string(8) "HTTP/1.1" ["REQUEST_METHOD"]=> string(3) "GET" ["QUERY_STRING"]=> string(0) "" ["REQUEST_URI"]=> string(10) "/index.php" ["SCRIPT_NAME"]=> string(10) "/index.php" ["PHP_SELF"]=> string(10) "/index.php" ["REQUEST_TIME_FLOAT"]=> float(1711695446.444052) ["REQUEST_TIME"]=> int(1711695446) }
+    Apache/2.4.58 (Ubuntu) Server at xxx.xxx.xxx.xxx Port 80
+    " ["SERVER_SOFTWARE"]=> string(22) "Apache/2.4.58 (Ubuntu)" ["SERVER_NAME"]=> string(14) "xxx.xxx.xxx.xxx" ["SERVER_ADDR"]=> string(12) "172.31.36.76" ["SERVER_PORT"]=> string(2) "80" ["REMOTE_ADDR"]=> string(14) "133.106.241.38" ["DOCUMENT_ROOT"]=> string(13) "/var/www/html" ["REQUEST_SCHEME"]=> string(4) "http" ["CONTEXT_PREFIX"]=> string(0) "" ["CONTEXT_DOCUMENT_ROOT"]=> string(13) "/var/www/html" ["SERVER_ADMIN"]=> string(19) "webmaster@localhost" ["SCRIPT_FILENAME"]=> string(23) "/var/www/html/test.php" ["REMOTE_PORT"]=> string(5) "50368" ["GATEWAY_INTERFACE"]=> string(7) "CGI/1.1" ["SERVER_PROTOCOL"]=> string(8) "HTTP/1.1" ["REQUEST_METHOD"]=> string(3) "GET" ["QUERY_STRING"]=> string(0) "" ["REQUEST_URI"]=> string(10) "/test.php" ["SCRIPT_NAME"]=> string(10) "/test.php" ["PHP_SELF"]=> string(10) "/test.php" ["REQUEST_TIME_FLOAT"]=> float(1711695446.444052) ["REQUEST_TIME"]=> int(1711695446) }
 
     ```
 
-    この結果から、`SERVER_SOFTWARE` の値が `Apache/2.4.52 (Ubuntu)` であることがわかります。これは、Apache ウェブサーバーが現在実行中であることを示しています。
+    この結果から、`SERVER_SOFTWARE` の値が `Apache/2.4.58 (Ubuntu)` であることがわかります。これは、Apache ウェブサーバーが現在実行中であることを示しています。
 
     ```php
-    ["SERVER_SOFTWARE"]=> string(22) "Apache/2.4.52 (Ubuntu)"
+    ["SERVER_SOFTWARE"]=> string(22) "Apache/2.4.58 (Ubuntu)"
     ```
 
 ### 判定のためにサーバー情報を.envファイルに記載しよう

--- a/new_graduate_training/tasks/infrastructure_training/task_items/use_nginx_ja.md
+++ b/new_graduate_training/tasks/infrastructure_training/task_items/use_nginx_ja.md
@@ -8,10 +8,6 @@ nginx をインストールするには、以下のコマンドを実行しま�
 $ sudo apt install nginx
 ```
 
-インストール時に下記のような画面が表示される場合があるので、デフォルトの選択肢で OK します。
-
-- <img width="580" alt="image" src="https://github.com/Progate/path-community-projects/assets/26600620/823ea2a0-ed40-40bf-bf2c-bb9c0a692b88">
-
 ### nginxでphp-fpmにリバースプロキシしてみよう
 
 リバースプロキシとは、クライアントからのリクエストを別のサーバーに転送する仕組みのことです。nginx を使用して、PHP リクエストを `php-fpm` にリバースプロキシできます。
@@ -33,8 +29,8 @@ $ sudo apt install nginx
         root /var/www/html;
 
         location / {
-            fastcgi_pass unix:/run/php/php8.1-fpm.sock;
-            fastcgi_index index.php;
+            fastcgi_pass unix:/run/php/php8.3-fpm.sock;
+            fastcgi_index test.php;
             include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         }
@@ -130,8 +126,8 @@ $ sudo apt install nginx
 
 `http://php.aws` でアクセスしてみましょう。Apatche のデフォルトのウェルカムページではなく、PHP の情報が表示されるはずです。
 
-SERVER_SOFTWARE の値が `Apache/2.4.52 (Ubuntu)` ではなく、`nginx/1.18.0` になっていることを確認してください。
+SERVER_SOFTWARE の値が `Apache/2.4.58 (Ubuntu)` ではなく、`nginx/1.24.0` になっていることを確認してください。
 
 ```php
-["SERVER_SOFTWARE"]=> string(12) "nginx/1.18.0"
+["SERVER_SOFTWARE"]=> string(12) "nginx/1.24.0"
 ```


### PR DESCRIPTION
いただいた下記のレビューに対応しました。

* `sudo apt install emacs`をするとかなり時間がかかるのと、emacs以外にも色々インストールされて面倒なので書かない方がよさそう
  * 削除して対応
* index.htmlとindex.phpのどっちが優先されるのか分かりにくい問題があるので、test.phpなど、別の名前にしたい
  *   test.php に変更。関連箇所を修正
* Ubuntu 24.04は`sudo apt install php8.3-fpm` or `sudo apt install php-fpm`でインストールできるので、8.3前提に変更する
  * add-apt-repositoryのくだりは削除したい
  * その後の設定ファイルの場所も全部8.3に変更する
  * →php8.3-fpmに変更。動作確認で問題なかったのでadd-apt-repositoryのくだりを削除。関連箇所を修正
* apache・nginxのバージョンが古い
  * おそらくUbuntu 22.04前提になっている？
  * → Aapcheを2.4.52→2.4.58
  * →Ngonxを1.18.0→1.24.0
* `cat /var/log/nginx/access.log`は辞めて欲しい
  * 社内でログファイルは絶対にcatせずにtailするように厳しく言っているので、tailを利用してそのことについても触れて欲しい
  * → tail -f に変更。アコーディオンでcatではなくtailを使う理由を追記
* カスタムログフォーマットの定義について
  *  `/etc/nginx/nginx.conf`のhttpコンテキストの中に既にアクセスログの設定が書かれているので、別ファイルに設定を足すとどれが動くのかよく分からなくなるので、既存のアクセスログの設定を変更するようにしたい
  * →`/etc/nginx/nginx.conf`に追加するように変更。
 
その他QAで見つけた点を微修正


